### PR TITLE
Fix-flashing-scrollbar

### DIFF
--- a/src/components/BottomBar.tsx
+++ b/src/components/BottomBar.tsx
@@ -1,4 +1,3 @@
-import { TrackSource, useTracks } from "@livekit/components-react";
 import { MicrophoneMuteButton } from "./MicrophoneMuteButton";
 import { MicrophoneSelector } from "./MicrophoneSelector";
 import { PoweredByLiveKit } from "./PoweredByLiveKit";


### PR DESCRIPTION
Toggling the mute mic button causes scrollbars (vertical and horizontal) to appear for a fraction of a second. Happened on narrow viewport.